### PR TITLE
style: fix rustfmt blank line

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![doc = include_str!("../README.md")]
-
 #![deny(missing_docs)]
 #![deny(clippy::all)]
 


### PR DESCRIPTION
Removes a stray blank line between `include_str!` and `#![deny(...)]` that nightly rustfmt flags.